### PR TITLE
implement country subdivision lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ const countryName = findCountryName('GB-WLS') // "UK"
 
 ## Go (module)
 
-__TODO__ Handle subdivision lookup
-
 Example usage within your go project:
 
 ```go
@@ -154,11 +152,12 @@ Run `go mod tidy` once.
 
 ### `GetCountryNameByCode`
 
-This function will always return a string and fallback to "Unbekannt" if the given country cannot be found.
+This function will always return a string and fallback to "Unbekannt" if the given country cannot be found. It also accepts a country code with subdivision, e.g. `GB-ENG`.
 
 ### `FindCountryByCode`
 
-This function returns an error if the given country cannot be found.
+This function returns an error if the given country or subdivision cannot be found.
+It accepts both an alpha2 like `CA` or country code with subdivision, e.g. `GB-ENG`.
 
 Example usage:
 
@@ -166,9 +165,18 @@ Example usage:
 country, err := ak_countries.FindCountryByCode("MT")
 
 if err == nil {
-  log.Printf("Mit dem Rad nach %s (%s)?", country.Name, country.Alpha2)
+  log.Printf("Mit dem Rad nach %s (%s)?", country.Name, country.Code)
 }
 ```
+
+### `GetCountryNameByAlpha2`
+
+Return a name for the country with given alpha2 code. Returns "Unbekannt" if it cannot be found.
+
+### `FindCountryByAlpha2`
+
+Return a country by its alpha2 code. Fails with an error if the country cannot be found.
+
 
 ## How to update data and where does it come from?
 

--- a/countries.go
+++ b/countries.go
@@ -4,12 +4,17 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 )
 
 //go:embed countries.json
 var countriesFile []byte
 
+// A list of countries (with alpha2 identifiers) where some have additional subdivision
 var Countries []Country
+
+// A linear list of countries or subdivisions identified by a code like `CA` or `GB-ENG`
+var CountriesByCodes []CountryOrSubdivision
 
 type Subdivision struct {
 	Code string `json:"code"`
@@ -22,21 +27,44 @@ type Country struct {
 	Subdivisions *[]Subdivision `json:"subdivisions"`
 }
 
+type CountryOrSubdivision struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
 // Load countries on module load
 func init() {
 	if err := json.Unmarshal(countriesFile, &Countries); err != nil {
 		// This should not happen, but if it does we should fail hard/early
 		panic(err)
 	}
+	for _, country := range Countries {
+		CountriesByCodes = append(CountriesByCodes, CountryOrSubdivision{
+			Code: country.Alpha2,
+			Name: country.Name,
+		})
+
+		if country.Subdivisions != nil {
+			for _, subdivision := range *country.Subdivisions {
+				subdivisionCode := fmt.Sprintf("%s-%s", country.Alpha2, subdivision.Code)
+
+				CountriesByCodes = append(CountriesByCodes, CountryOrSubdivision{
+					Code: subdivisionCode,
+					Name: subdivision.Name,
+				})
+			}
+		}
+	}
 }
 
-// Find a country by code from the given list of countries
-// When the given code cannot be found, will return nil, error!
-func FindCountryByCode(code string) (*Country, error) {
+// Find a country by ISO 3166-1 alpha-2 from the given list of countries
+// When it cannot be found, will return nil, error!
+//
+// see: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+func FindCountryByAlpha2(alpha2 string) (*Country, error) {
 	var country *Country
-
 	for _, entry := range Countries {
-		if entry.Alpha2 == code {
+		if entry.Alpha2 == alpha2 {
 			country = &entry
 			break
 		}
@@ -44,12 +72,49 @@ func FindCountryByCode(code string) (*Country, error) {
 
 	if country == nil {
 		return nil, errors.New("Failed to find Country")
+	}
+
+	return country, nil
+}
+
+// Get a name for a country by alpha2 from the given list of countries
+// When given code cannot be found returns "Unbekannt"
+func GetCountryNameByAlpha2(alpha2 string) string {
+	country, err := FindCountryByAlpha2(alpha2)
+
+	if err == nil {
+		return country.Name
 	} else {
-		return country, nil
+		return "Unbekannt"
 	}
 }
 
+// Find a country by code from the given list of countries
+// When it cannot be found, will return nil, error!
+//
+// Code is either an alpha2 code (ISO 3166-1), like `CA`
+// or a specific a subdivision code (ISO 3166-2), like `GB-ENG`
+//
+// see: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+// and: https://en.wikipedia.org/wiki/ISO_3166-2
+func FindCountryByCode(code string) (*CountryOrSubdivision, error) {
+	var country *CountryOrSubdivision
+	for _, entry := range CountriesByCodes {
+		if entry.Code == code {
+			country = &entry
+			break
+		}
+	}
+
+	if country == nil {
+		return nil, errors.New("Failed to find Country")
+	}
+
+	return country, nil
+}
+
 // Get a name for a country by code from the given list of countries
+// and their subdivisions.
 // When given code cannot be found returns "Unbekannt"
 func GetCountryNameByCode(code string) string {
 	country, err := FindCountryByCode(code)

--- a/countries_test.go
+++ b/countries_test.go
@@ -78,3 +78,40 @@ func TestGetCountryNameByCode(t *testing.T) {
 		t.Fatalf("Expected Country name to be 'Kanada' but got: %v", name)
 	}
 }
+
+func TestGetCountryNameByCodeWithSubdivision(t *testing.T) {
+	name := GetCountryNameByCode("GB-ENG")
+
+	if name != "England" {
+		t.Fatalf("Expected Country name to be 'England' but got: %v", name)
+	}
+}
+
+func TestFindCountryByAlpha2(t *testing.T) {
+	country, err := FindCountryByAlpha2("CA")
+
+	if err != nil {
+		t.Fatalf("Failed finding country with code CA: %v", err)
+	}
+
+	if country.Name != "Kanada" {
+		t.Fatalf("Expected Country with name 'Kanada', but got: %v", country.Name)
+	}
+}
+
+// Ensure we cannot accidentally return subdivisions here
+func TestFindCountryByAlpha2Fail(t *testing.T) {
+	_, err := FindCountryByAlpha2("GB-ENG")
+
+	if err == nil {
+		t.Fatalf("Expected finding country to fail, but it did not")
+	}
+}
+
+func TestGetCountryNameByAlpha2(t *testing.T) {
+	name := GetCountryNameByAlpha2("CA")
+
+	if name != "Kanada" {
+		t.Fatalf("Expected Country name to be 'Kanada' but got: %v", name)
+	}
+}


### PR DESCRIPTION
Breaking changes: returned countries now contain `Code` instead of `Alpha2` as they might be something like `GB-ENG`

move to dedicated alpha2 only api

closes #3